### PR TITLE
Add optional debug mode for WebGL calls

### DIFF
--- a/bindgen.js
+++ b/bindgen.js
@@ -195,6 +195,9 @@ function createProcDef(name, retType, args) {
     } else {
         body.push(`${name}(${callArgs});`)
     }
+    body.push('#ifdef WEBGL_DEBUG');
+    body.push(`DEBUG_GL_CHECK(ctx, "${name}", argc, argv);`);
+    body.push('#endif');
 
     const proc = `static JSValue js_${name}(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
 {


### PR DESCRIPTION
## Summary
- add helper macros in `additions.c` for debug logging
- invoke the macros after GLUT and GL calls
- extend `bindgen.js` so generated wrappers log failures when `WEBGL_DEBUG` is defined

## Testing
- `make test` *(fails: No rule to make target 'quickjs/qjs.c')*